### PR TITLE
Add default system prompt with tool use guidance

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -78,6 +78,7 @@ func (a *Agent) EstimateCurrentTokens() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	tokens := EstimateTokens(a.history)
+	tokens += EstimateSystemPromptTokens(DefaultSystemPrompt)
 	if a.claudeCfg != nil {
 		tokens += EstimateSystemPromptTokens(a.claudeCfg.SystemPrompt)
 	}
@@ -311,6 +312,12 @@ func (a *Agent) Run(ctx context.Context, userPrompt string) <-chan AgentEvent {
 			toolDefs = a.registry.ToolDefs()
 		}
 
+		// Build full system prompt: Ernest defaults + user/project CLAUDE.md
+		systemPrompt := DefaultSystemPrompt
+		if a.claudeCfg != nil && a.claudeCfg.SystemPrompt != "" {
+			systemPrompt += "\n\n---\n\n" + a.claudeCfg.SystemPrompt
+		}
+
 		for iteration := 0; iteration < maxToolLoops; iteration++ {
 			a.mu.Lock()
 			history := make([]provider.Message, len(a.history))
@@ -318,7 +325,7 @@ func (a *Agent) Run(ctx context.Context, userPrompt string) <-chan AgentEvent {
 			a.mu.Unlock()
 
 			streamCh, providerName, err := a.router.Stream(
-				ctx, a.claudeCfg.SystemPrompt, history, toolDefs,
+				ctx, systemPrompt, history, toolDefs,
 			)
 			if err != nil {
 				events <- AgentEvent{Type: "error", Error: err}

--- a/internal/agent/system_prompt.go
+++ b/internal/agent/system_prompt.go
@@ -1,0 +1,25 @@
+package agent
+
+// DefaultSystemPrompt is prepended to the user/project CLAUDE.md content
+// to give the model guidance on how to use Ernest's tools effectively.
+const DefaultSystemPrompt = `You are Ernest, an AI coding assistant running in a terminal. You help users with software engineering tasks by reading, writing, and searching code.
+
+## Tools
+
+You have access to these tools:
+
+- **read_file**: Read file contents with line numbers. Use for viewing specific files.
+- **write_file**: Create or overwrite files. Creates parent directories as needed.
+- **str_replace**: Replace exact strings in files. Preferred for targeted edits — do not rewrite entire files when a small change suffices.
+- **bash**: Execute shell commands. Use for running tests, builds, git operations, and other system tasks.
+- **glob**: Find files by pattern (supports ** for recursive matching). Use before grep to locate files.
+- **grep**: Search file contents with regex. Use to find specific code, definitions, or usage patterns.
+
+## Guidelines
+
+- Before editing a file, read it first to understand the context.
+- Use glob to find files before grepping — don't guess paths.
+- Prefer str_replace for small changes over write_file for the whole file.
+- When running commands with bash, keep them focused. One logical operation per command.
+- If a command fails, read the error and adapt. Don't retry the same thing.
+- Be terse in your responses. Lead with actions, not explanations.`


### PR DESCRIPTION
## Summary

Adds a default system prompt that describes Ernest's tools and provides usage guidelines. Prepended to user/project CLAUDE.md content so user instructions can override.

Resolves #12

### What changed

- `internal/agent/system_prompt.go` — Default prompt constant describing all 6 tools with guidelines
- `internal/agent/loop.go` — Prepends default prompt to Claude config system prompt, included in token estimation

### Guidelines in the prompt

- Read files before editing
- Use glob to find files before grepping
- Prefer str_replace for small changes over write_file
- Keep bash commands focused
- Be terse — lead with actions

### Design

- Ernest defaults come first, user/project CLAUDE.md appended after a separator
- User instructions can override or augment the defaults
- Token estimation includes the default prompt

## Test plan

- [x] All existing tests pass (prompt prepending doesn't break agent behavior)
- [x] Manual: model now uses tools more effectively (globs before grepping, uses str_replace for edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)